### PR TITLE
fix: Change grep to detect currently mounted filesystem

### DIFF
--- a/loaders-update
+++ b/loaders-update
@@ -222,7 +222,7 @@ if [ -n "$BIOSD" ]; then
 	echo 'One or more freebsd-boot partition(s) have been found.'
 
 	# Check the root file system
-	rfs="$(mount -p | grep "	/	" | awk '{ print $3 }')"
+	rfs="$(mount -p | grep "\s/\s" | awk '{ print $3 }')"
 	if [ -n "$rfs" ]; then
 		echo "The root file system is $rfs."
 		CheckSourceFile /boot/pmbr


### PR DESCRIPTION
grep was using tabs, while mount's output is most of the time spaces
regex now uses '\s' modifier, which is supported on all PCRE/PCRE2-compiled versions of grep